### PR TITLE
Add 'make install' target and package config file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-
 cmake_minimum_required(VERSION 3.12)
-project(ers)
+project(ers VERSION 1.0.0)
 
 set(Boost_USE_STATIC_LIBS OFF)
 # set(Boost_NO_BOOST_CMAKE ON)
@@ -9,7 +8,71 @@ set(BUILD_SHARED_LIBS ON)
 set(CMAKE_CXX_STANDARD 17)
 
 include_directories(${CMAKE_SOURCE_DIR}/ers)
+include_directories(${CMAKE_SOURCE_DIR})
 
 add_subdirectory(bin)
 add_subdirectory(src)
 add_subdirectory(test)
+
+# Installation stuff copied from the double-conversion CMakeLists.txt, which in turn got it from
+# https://github.com/forexample/package-example
+
+include(GNUInstallDirs)
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib/cmake/<PROJECT-NAME>
+#   * <prefix>/lib/
+#   * <prefix>/include/
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with function 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Note: PROJECT_VERSION is used as a VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * targets_export_name
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+install(
+    TARGETS ers ErsBaseStreams config
+    EXPORT "${targets_export_name}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+install(
+    DIRECTORY ers
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,12 @@
 
+find_package(Boost COMPONENTS regex preprocessor) 
+
 file(GLOB source_files "*.cxx")
 add_library(ers SHARED ${source_files})
-target_link_libraries(ers pthread dl)
+target_link_libraries(ers pthread dl Boost::preprocessor)
 
 
-find_package(Boost COMPONENTS regex) 
+
 message(${Boost_REGEX_LIBRARIES})
 
 file(GLOB streams_srcs "streams/*.cxx")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,9 +1,11 @@
 
-find_package(Boost COMPONENTS regex preprocessor) 
+find_package(Boost COMPONENTS regex REQUIRED) 
+
+include_directories(${Boost_INCLUDE_DIRS})
 
 file(GLOB source_files "*.cxx")
 add_library(ers SHARED ${source_files})
-target_link_libraries(ers pthread dl Boost::preprocessor)
+target_link_libraries(ers pthread dl)
 
 
 


### PR DESCRIPTION
This pull request adds a `make install` target that installs the ers headers and libraries, and uses the cmake package config system to make `find_package(ers)` work for cmake packages that depend on it