### PR TITLE
Move install()s to subdirectory CMakeLists.txt so it works with CMake…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.10)
 project(ers VERSION 1.0.0)
 
 set(Boost_USE_STATIC_LIBS OFF)
@@ -7,15 +7,10 @@ set(BUILD_SHARED_LIBS ON)
 
 set(CMAKE_CXX_STANDARD 17)
 
-include_directories(${CMAKE_SOURCE_DIR}/ers)
-include_directories(${CMAKE_SOURCE_DIR})
-
-add_subdirectory(bin)
-add_subdirectory(src)
-add_subdirectory(test)
-
 # Installation stuff copied from the double-conversion CMakeLists.txt, which in turn got it from
 # https://github.com/forexample/package-example
+#
+# We set up the installation variables first because we'll use them in the add_subdirectory()s
 
 include(GNUInstallDirs)
 
@@ -32,6 +27,10 @@ set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
 set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
 set(targets_export_name "${PROJECT_NAME}Targets")
 set(namespace "${PROJECT_NAME}::")
+
+add_subdirectory(bin)
+add_subdirectory(src)
+add_subdirectory(test)
 
 # Include module with function 'write_basic_package_version_file'
 include(CMakePackageConfigHelpers)
@@ -50,15 +49,6 @@ configure_package_config_file(
     "cmake/Config.cmake.in"
     "${project_config}"
     INSTALL_DESTINATION "${config_install_dir}"
-)
-
-install(
-    TARGETS ers ErsBaseStreams config
-    EXPORT "${targets_export_name}"
-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
 install(

--- a/bin/CMakeLists.txt
+++ b/bin/CMakeLists.txt
@@ -2,3 +2,8 @@ include_directories(${CMAKE_SOURCE_DIR}/ers)
 
 add_executable(config config.cxx)
 target_link_libraries(config ${CMAKE_DL_LIBS} ers)
+
+install(
+    TARGETS config
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,18 +1,30 @@
-
 find_package(Boost COMPONENTS regex REQUIRED) 
-
-include_directories(${Boost_INCLUDE_DIRS})
+message(STATUS ${Boost_REGEX_LIBRARIES})
 
 file(GLOB source_files "*.cxx")
 add_library(ers SHARED ${source_files})
 target_link_libraries(ers pthread dl)
-
-
-
-message(${Boost_REGEX_LIBRARIES})
+# The $<> stuff below are generator expressions. At build time, we
+# will look for includes in the source directory, but for dependencies
+# that are compiling/linking against ers, they will need to look in
+# the install directory (the argument of $<INSTALL_INTERFACE> is
+# interpreted relative to ${CMAKE_INSTALL_PREFIX}. See:
+#
+# https://cliutils.gitlab.io/modern-cmake/chapters/basics/functions.html#generator-expressions
+target_include_directories(ers
+  PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:ers>
+)
 
 file(GLOB streams_srcs "streams/*.cxx")
 add_library(ErsBaseStreams MODULE ${streams_srcs})
 target_link_libraries(ErsBaseStreams ers Boost::regex)
 
+include(GNUInstallDirs)
 
+install(
+    TARGETS ers ErsBaseStreams
+    EXPORT "${targets_export_name}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(ers pthread dl)
 target_include_directories(ers
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}>
-  $<INSTALL_INTERFACE:ers>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 file(GLOB streams_srcs "streams/*.cxx")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${CMAKE_SOURCE_DIR}/ers)
 
-add_executable(test test.cxx)
-target_link_libraries(test ${CMAKE_DL_LIBS} ers pthread)
+add_executable(ers-test test.cxx)
+target_link_libraries(ers-test ${CMAKE_DL_LIBS} ers pthread)
 
 add_executable(receiver receiver.cxx)
 target_link_libraries(receiver ${CMAKE_DL_LIBS} ers pthread)


### PR DESCRIPTION
… <3.13, and other tidying

* Use target_include_directories on the ers target, instead of global include_directories()
* Rename 'test' target to 'ers-test', because 'test' is a reserved name: https://cmake.org/cmake/help/latest/policy/CMP0037.html