### PR TITLE
Glm/no macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ The following example shows a typical use case of handling ERS exceptions.
 This example demonstrates the main features of the ERS API:
  * An issue does not have severity by itself. Severity of the issue is defined by the stream to which this issue is reported.
  * An issue can be send to one of the existing ERS streams using one of the following functions:
-ers::debug, ers::info, ers::warning, ers::error, ers::fatal
+ers::info, ers::warning, ers::error, ers::fatal
  * Any ERS issue has a constructor, which accepts another issue as its last parameter. If this
 constructor is used the new issue will hold the copy of the original one and will report it as its cause.
  * Any ERS issue has a constructor, which accepts std::exception issue as its last parameter.
@@ -256,8 +256,6 @@ constructor is used the new issue will hold the copy of the original one and wil
 The ERS system provides multiple instances of the stream API, one per severity level, to report issues.
 The issues which are sent to different streams may be forwarded to different destinations depending on a
 particular stream configuration. By default the ERS streams are configured in the following way:
- * ers::debug - "lstdout" - prints issues to the standard C++ output stream
- * ers::log - "lstdout" - prints issues to the standard C++ output stream
  * ers::info - "throttle,lstdout" - prints throttled issues to the standard C++ output stream
  * ers::warning - "throttle,lstderr" - prints throttled issues to the standard C++ error stream
  * ers::error - "throttle,lstderr" - prints throttled issues to the standard C++ error stream

--- a/README.md
+++ b/README.md
@@ -32,35 +32,11 @@ but does not allow the checked value to be equal to either min or max values.
 
 > **Note:** These macro are defined to empty statements if **ERS_NO_DEBUG** macro is defined at compilation time.
 
-## Logging Macro
-ERS package offers a set of macro for infromation logging:
- * **ERS_DEBUG( level, message )** - sends ers::Message issue to the ers::debug stream
- * **ERS_LOG( message )** - sends ers::Message issue to the ers::log stream
- * **ERS_INFO( message )** - sends ers::Message issue to the ers::information stream
- 
-> **Note:** ERS_DEBUG macro is defined to empty statement if **ERS_NO_DEBUG** macro is defined at compilation time.
-
-Each of these macro constructs an new issue of ers::Message time and sends it to an appropriate stream.
-The **message** argument of these macro can be any value, for which the standard C++ output stream operator
-(**operator<<**) is defined. This means that the message can be a single value of a certain type as well
-as a sequence of output operations of any supported types.
-For example:
-
-~~~cpp
-ERS_DEBUG( 1, "simple debug output " << 123 << " that shows how to use debug macro" )
-~~~
-
-The actual behavior of these macro depends on the configuration of a respective stream.
-Debug macro can be disabled at run-time by defining the **TDAQ_ERS_DEBUG_LEVEL** environment 
-variable to the highest possible debug level.
-For instance, if **TDAQ_ERS_DEBUG_LEVEL** is set to N, then **ERS_DEBUG( M, ... )** where **M > N**
-will not produce any output. The default value for the **TDAQ_ERS_DEBUG_LEVEL** is 0. Negative
-debug levels are also allowed.
 
 The amount of information, which is printed for an issue depends on the actual ERS verbosity level,
 which can be controlled via the **TDAQ_ERS_VERBOSITY_LEVEL** macro. Default verbosity level is zero.
 In this case the following information is reported for any issue:
- * severity (DEBUG, LOG, INFO, WARNING, ERROR, FATAL)
+ * severity (INFO, WARNING, ERROR, FATAL)
  * the time of the issue occurrence
  * the issue's context, which includes package name, file name, function name and line number
  * the issue's message
@@ -259,7 +235,6 @@ The following example shows a typical use case of handling ERS exceptions.
         ers::warning( issue );
     }
     catch ( ers::Issue & ex ) {
-        ERS_DEBUG( 0, "Unknown issue caught: " << ex )
         ers::error( ex );
     }
     catch ( std::exception & ex ) {

--- a/ers/Configuration.h
+++ b/ers/Configuration.h
@@ -27,11 +27,9 @@ namespace ers
       * \author Serguei Kolos
       * \version 1.2
       * \brief Manager of ERS streams configuration. 
-      * \see ers::debug
       * \see ers::error
       * \see ers::fatal
       * \see ers::information
-      * \see ers::log
       * \see ers::warning
       */
     
@@ -44,21 +42,14 @@ namespace ers
 	        
   	static Configuration & instance();	/**< \brief return the singleton */
         
-        int debug_level() const			/**< \brief returns current debug level */
-        { return m_debug_level; }
-        
         int verbosity_level() const		/**< \brief returns current verbosity level */
         { return m_verbosity_level; }
-        
-        void debug_level( int debug_level )	/**< \brief can be used to set the current debug level */
-        { m_debug_level = debug_level; }
         
         void verbosity_level( int verbosity_level );	/**< \brief can be used to set the current verbosity level */
         
       private:	
 	Configuration( );
                 
-        int m_debug_level;		/**< \brief current active level for the debug stream */	
     	int m_verbosity_level;		/**< \brief current verbosity level for all streams */
     };
     

--- a/ers/LocalStream.h
+++ b/ers/LocalStream.h
@@ -64,6 +64,8 @@ namespace ers
 	
         void warning( const ers::Issue & issue );
 
+        void information( const ers::Issue & issue );
+
       private:
 	LocalStream( );
 	~LocalStream( );

--- a/ers/Severity.h
+++ b/ers/Severity.h
@@ -23,7 +23,7 @@ namespace ers
 {
     class BadSeverity;
     
-    enum severity { Debug, Log, Information, Warning, Error, Fatal };
+    enum severity { Information, Warning, Error, Fatal };
     
     struct Severity
     {

--- a/ers/StreamManager.h
+++ b/ers/StreamManager.h
@@ -47,11 +47,9 @@ namespace ers
       * 
       * \author Serguei Kolos
       * \brief This class manages and provides access to ERS streams.
-      * \see ers::debug
       * \see ers::error
       * \see ers::fatal
       * \see ers::infomation
-      * \see ers::log
       * \see ers::warning
       */
     
@@ -67,16 +65,12 @@ namespace ers
         ~StreamManager();
         
   	static StreamManager & instance();		/**< \brief return the singleton */
-        
-	void debug( const Issue & issue, int level );	/**< \brief sends an Issue to the debug stream */
 	
         void error( const Issue & issue );		/**< \brief sends an issue to the error stream */
 	
         void fatal( const Issue & issue );		/**< \brief sends an issue to the fatal stream */
 	
         void information( const Issue & issue );	/**< \brief sends an issue to the information stream */
-	
-        void log( const Issue & issue );		/**< \brief sends an issue to the log stream */
         
         void warning( const Issue & issue );		/**< \brief sends an issue to the warning stream */
 

--- a/ers/ers.h
+++ b/ers/ers.h
@@ -47,7 +47,7 @@ namespace ers
     /*!
      *	This function sets up the local issue handler function. This function will be executed in the context
      *	of dedicated thread which will be created as a result of this call. All the issues which are reported
-     *	via the ers::error, ers::fatal and ers::warning functions will be forwarded to this thread.
+     *	via the ers::error, ers::fatal and ers::warning ers::info functions will be forwarded to this thread.
      *	\param issue the issue to be reported
      *	\return pointer to the handler object, which allows to remove the catcher by just destroying this object.
      *			If an applications ignores this return value there will no way of de installing the issue catcher.
@@ -55,24 +55,12 @@ namespace ers
      *	\see ers::error()
      *	\see ers::fatal()
      *	\see ers::warning()
+     *	\see ers::info()
      */
     inline IssueCatcherHandler * 
     	set_issue_catcher( const std::function<void ( const ers::Issue & )> & catcher )
     { return LocalStream::instance().set_issue_catcher( catcher ); }
     
-    /*! 
-     *  This function returns the current debug level for ERS.
-     */
-    inline int debug_level( )
-    { return Configuration::instance().debug_level( ); }
-    
-    /*! 
-     *  This function sends the issue to the ERS DEBUG stream which corresponds to the given debug level.
-     *  \param issue the issue to be reported
-     *  \level debug level which will be associated with the reported issue
-     */
-    inline void debug( const Issue & issue, int level = debug_level() )
-    { StreamManager::instance().debug( issue, level ); }
     
     /*! 
      *  This function sends the issue to the ERS ERROR stream.
@@ -93,14 +81,7 @@ namespace ers
      *  \param issue the issue to be reported
      */
     inline void info( const Issue & issue )
-    { StreamManager::instance().information( issue ); }
-    
-    /*! 
-     *  This function sends the issue to the ERS LOG stream.
-     *  \param issue the issue to be reported
-     */
-    inline void log( const Issue & issue )
-    { StreamManager::instance().log( issue ); }
+    { LocalStream::instance().information( issue ); }
     
     /*! 
      *  This function returns the current verbosity level for ERS.
@@ -121,7 +102,7 @@ namespace ers
     }
 }
 
-ERS_DECLARE_ISSUE( ers, Message, ERS_EMPTY, ERS_EMPTY )
+//ERS_DECLARE_ISSUE( ers, Message, ERS_EMPTY, ERS_EMPTY )
 
 #define ERS_REPORT_IMPL( stream, issue, message, level ) \
 { \
@@ -130,34 +111,6 @@ ERS_DECLARE_ISSUE( ers, Message, ERS_EMPTY, ERS_EMPTY )
     stream( issue( ERS_HERE, ers_report_impl_out_buffer.str() ) \
 	    BOOST_PP_COMMA_IF( BOOST_PP_NOT( ERS_IS_EMPTY( ERS_EMPTY level ) ) ) level ); \
 }
-
-#ifndef ERS_NO_DEBUG
-/** \def ERS_DEBUG( level, message) This macro sends the message to the ers::debug stream
- * if level is less or equal to the TDAQ_ERS_DEBUG_LEVEL, which is equal to 0 by default.
- * \note This macro is defined to empty statement if the \c ERS_NO_DEBUG macro is defined
- */
-#define ERS_DEBUG( level, message ) do { \
-if ( ers::debug_level() >= level ) \
-{ \
-    ERS_REPORT_IMPL( ers::debug, ers::Message, message, level ); \
-} } while(0)
-#else
-#define ERS_DEBUG( level, message ) do { } while(0)
-#endif
-
-/** \def ERS_INFO( message ) This macro sends the message to the ers::info stream.
- */
-#define ERS_INFO( message ) do { \
-{ \
-    ERS_REPORT_IMPL( ers::info, ers::Message, message, ERS_EMPTY ); \
-} } while(0)
-
-/** \def ERS_LOG( message ) This macro sends the message to the ers::log stream.
- */
-#define ERS_LOG( message ) do { \
-{ \
-    ERS_REPORT_IMPL( ers::log, ers::Message, message, ERS_EMPTY ); \
-} } while(0)
 
 #endif // ERS_ERS_H
 

--- a/ers/internal/macro.h
+++ b/ers/internal/macro.h
@@ -22,16 +22,6 @@ namespace { \
         { ers::StreamFactory::instance().register_out_stream( name, create ); } \
     } BOOST_PP_CAT( registrator, __LINE__ ); \
 }
- 
-#define ERS_INTERNAL_DEBUG( level, message ) { \
-if ( ers::debug_level() >= level ) \
-{ \
-    std::ostringstream out; \
-    out << message; \
-    ers::InternalMessage info( ERS_HERE, out.str() ); \
-    info.set_severity( ers::Severity( ers::Debug, level ) ); \
-    ers::StandardStreamOutput::println( std::cout, info, 0 ); \
-} }
 
 #define ERS_INTERNAL_INFO( message ) { \
     std::ostringstream out; \

--- a/pytest/erstest.py
+++ b/pytest/erstest.py
@@ -34,7 +34,7 @@ class CantOpenFile( Exception ):
 
 #create the logger
 logger = logging.getLogger("main")
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 
 #add ers handler
 ers.addLoggingHandler("main")
@@ -49,7 +49,6 @@ class Test(object):
             
 def test_function( arg1, arg2 ):
     format = 'This is a %s message #%d'
-    logger.debug(format, 'debug', 1 )
     logger.info(format, 'info', 2 )
     logger.warning(format, 'warning', 3 )
     logger.error(format, 'error', 4 )

--- a/python/ers.py
+++ b/python/ers.py
@@ -25,7 +25,7 @@ import time
 
 class Severity( object ):
     "defines supported severity values"
-    values = ( DEBUG , LOG, INFO, WARNING, ERROR, FATAL ) = tuple( range( 6 ) )
+    values = ( INFO, WARNING, ERROR, FATAL ) = tuple( range( 4 ) )
 
 SeverityNames = tuple ( [ [k for k, v in list(Severity.__dict__.items()) if v == s][0] \
                                         for s in Severity.values ] )
@@ -105,11 +105,6 @@ class Issue( Exception ):
     def __str__( self ):
         return self.message
 
-class Message( Issue ):
-    "this is wrapper for string message to be sent to debug, log and info streams"
-    def __init__( self, msg ):
-            Issue.__init__( self, msg, {}, None )
-
 if sys.platform == 'linux2':
     import DLFCN
     flags = sys.getdlopenflags()
@@ -119,17 +114,11 @@ if sys.platform == 'linux2':
 else:
     import liberspy
 liberspy.init( Issue )        
-                  
-def debug( lvl, msg ):
-    "sends msg to the debug stream"
-    liberspy.debug( lvl, isinstance( msg, Issue ) and msg or Message( msg ) )
-
-def log( msg ):
-    "sends msg to the log stream"
-    liberspy.log( isinstance( msg, Issue ) and msg or Message( msg ) )
 
 def info( msg ):
     "sends msg to the information stream"
+    assert isinstance(issue,Issue), \
+            'Only an instance of ers.Issue sub-class can be sent to the ers.warning stream'
     liberspy.info( isinstance( msg, Issue ) and msg or Message( msg ) )
 
 def warning( issue ):
@@ -151,8 +140,7 @@ def fatal( issue ):
     liberspy.fatal( issue )
 
 class LoggingHandler( logging.Handler ) :
-    severity_mapper = { logging.getLevelName( logging.DEBUG )   : lambda m: debug( 0, m ),
-                        logging.getLevelName( logging.INFO )    : info,
+    severity_mapper = { logging.getLevelName( logging.INFO )    : info,
                         logging.getLevelName( logging.WARNING ) : warning,
                         logging.getLevelName( logging.ERROR )   : error,
                         logging.getLevelName( logging.CRITICAL ): fatal }

--- a/python/erspy.cxx
+++ b/python/erspy.cxx
@@ -171,20 +171,6 @@ namespace
     }
     
     void
-    debug( int level, PyObject * o )
-    {
-    	std::unique_ptr<ers::Issue> a( issue( o ) );
-        ers::debug( *a, level );
-    }
-    
-    void
-    log( PyObject * o )
-    {
-    	std::unique_ptr<ers::Issue> a( issue( o ) );
-    	ers::log( *a );
-    }
-    
-    void
     info( PyObject * o )
     {
     	std::unique_ptr<ers::Issue> a( issue( o ) );
@@ -216,8 +202,6 @@ namespace
     {
 	boost::python::register_exception_translator<ers::Issue>(&translate_exception);
 	boost::python::def("init", &init);
-	boost::python::def("debug", &debug);
-	boost::python::def("log", &log);
 	boost::python::def("info", &info);
 	boost::python::def("warning", &warning);
 	boost::python::def("error", &error);

--- a/src/Configuration.cxx
+++ b/src/Configuration.cxx
@@ -32,10 +32,8 @@ ers::Configuration::instance()
   * \see instance() 
   */
 ers::Configuration::Configuration()
-  : m_debug_level( 0 ),
-    m_verbosity_level( 0 )
+  : m_verbosity_level( 0 )
 {
-    m_debug_level = read_from_environment( "TDAQ_ERS_DEBUG_LEVEL", m_debug_level );
     m_verbosity_level = read_from_environment( "TDAQ_ERS_VERBOSITY_LEVEL", m_verbosity_level );
 }
 
@@ -48,6 +46,6 @@ ers::Configuration::verbosity_level( int verbosity_level )
 std::ostream & 
 ers::operator<<( std::ostream & out, const ers::Configuration & conf )
 {
-    out << "debug level = " << conf.m_debug_level << " verbosity level = " << conf.m_verbosity_level;
+    out << " verbosity level = " << conf.m_verbosity_level;
     return out;
 }

--- a/src/IssueFactory.cxx
+++ b/src/IssueFactory.cxx
@@ -52,11 +52,9 @@ ers::IssueFactory::create(	const std::string & name,
     FunctionMap::const_iterator it = m_creators.find(name); 
     if ( it == m_creators.end() )
     {
-	ERS_INTERNAL_DEBUG( 1, "Creator for the \"" << name << "\" issue is not found" );
         return new ers::AnyIssue( name, context );
     }
     
-    ERS_INTERNAL_DEBUG( 2, "Creating the \"" << name << "\" issue" );
     return (it->second)( context ); 
 }
 

--- a/src/LocalStream.cxx
+++ b/src/LocalStream.cxx
@@ -126,3 +126,9 @@ ers::LocalStream::warning( const ers::Issue & issue )
 {
     report_issue( ers::Warning, issue );
 }
+
+void
+ers::LocalStream::information( const ers::Issue & issue )
+{
+    report_issue( ers::Information, issue );
+}

--- a/src/PluginManager.cxx
+++ b/src/PluginManager.cxx
@@ -69,7 +69,6 @@ namespace ers
 	}
 	catch( PluginException & ex )
 	{
-	    ERS_INTERNAL_DEBUG( 1, "Library " << MRSStreamLibraryName << " can not be loaded because " << ex.reason() )
 	}
         
 	for ( size_t i = 0; i < libs.size(); i++ )

--- a/src/Severity.cxx
+++ b/src/Severity.cxx
@@ -6,8 +6,6 @@ namespace
 {
     const char * SeverityNames[] =
     { 
-	"DEBUG",
-	"LOG",
 	"INFO",
 	"WARNING",
 	"ERROR",
@@ -29,7 +27,7 @@ ERS_DECLARE_ISSUE(	ers,
 std::string
 ers::to_string( ers::severity severity )
 {
-    assert( ers::Debug <= severity && severity <= ers::Fatal );
+    assert( ers::Information <= severity && severity <= ers::Fatal );
     return SeverityNames[severity];
 }
 
@@ -41,14 +39,8 @@ ers::to_string( ers::severity severity )
 std::string
 ers::to_string( ers::Severity severity )
 {
-    assert( ers::Debug <= severity && severity <= ers::Fatal );
+    assert( ers::Information <= severity && severity <= ers::Fatal );
 
-    if ( severity.type == ers::Debug )
-    {
-	std::ostringstream out;
-	out << SeverityNames[severity] << "_" << severity.rank;
-	return out.str();
-    }
     return SeverityNames[severity.type];
 }
 
@@ -59,7 +51,7 @@ ers::to_string( ers::Severity severity )
 ers::severity
 ers::parse( const std::string & string, ers::severity & s )
 {
-    for( short ss = ers::Debug; ss <= ers::Fatal; ++ss )
+    for( short ss = ers::Information; ss <= ers::Fatal; ++ss )
     {
 	if ( string == SeverityNames[ss] )
 	{

--- a/src/StreamManager.cxx
+++ b/src/StreamManager.cxx
@@ -39,8 +39,6 @@ namespace
     
     const char * const DefaultOutputStreams[] =
     {
-	"lstdout",		// Debug
-	"lstdout",		// Log
 	"throttle,lstdout",	// Information
 	"throttle,lstderr",	// Warning
         "throttle,lstderr",	// Error
@@ -50,7 +48,7 @@ namespace
     const char *
     get_stream_description( ers::severity severity )
     {
-	assert( ers::Debug <= severity && severity <= ers::Fatal );
+	assert( ers::Information <= severity && severity <= ers::Fatal );
         
 	std::string env_name( "TDAQ_ERS_" );
 	env_name += ers::to_string( severity );
@@ -162,7 +160,7 @@ ers::StreamManager::instance()
   */
 ers::StreamManager::StreamManager()
 {
-    for( short ss = ers::Debug; ss <= ers::Fatal; ++ss )
+    for( short ss = ers::Information; ss <= ers::Fatal; ++ss )
     {	
        m_init_streams[ss] = std::make_shared<StreamInitializer>( *this );
        m_out_streams[ss] = m_init_streams[ss];
@@ -318,21 +316,6 @@ ers::StreamManager::error( const Issue & issue )
     report_issue( ers::Error, issue );
 } // error
 
-/** Sends an issue to the debug stream 
- * \param issue the Issue to send
- * \param level the debug level. 
- */
-void
-ers::StreamManager::debug( const Issue & issue, int level )
-{
-    if ( Configuration::instance().debug_level() >= level )
-    {
-	ers::severity old_severity = issue.set_severity( ers::Severity( ers::Debug, level ) );
-	m_out_streams[ers::Debug]->write( issue );
-	issue.set_severity( old_severity );
-    }
-}
-
 /** Sends an Issue to the fatal error stream 
  * \param issue 
  */
@@ -360,19 +343,10 @@ ers::StreamManager::information( const Issue & issue )
     report_issue( ers::Information, issue );
 }
 
-/** Sends an issue to the log stream 
- * \param issue the Issue to send
- */
-void
-ers::StreamManager::log( const Issue & issue )
-{
-    report_issue( ers::Log, issue );
-}
-
 std::ostream & 
 ers::operator<<( std::ostream & out, const ers::StreamManager & )
 {
-    for( short ss = ers::Debug; ss <= ers::Fatal; ++ss )
+    for( short ss = ers::Information; ss <= ers::Fatal; ++ss )
     {	
 	out << (ers::severity)ss << "\t\"" 
         	<< get_stream_description( (ers::severity)ss ) << "\"" << std::endl;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories(${CMAKE_SOURCE_DIR}/ers)
 
-add_executable(test test.cxx)
-target_link_libraries(test ${CMAKE_DL_LIBS} ers pthread)
+add_executable(ers_test test.cxx)
+target_link_libraries(ers_test ${CMAKE_DL_LIBS} ers pthread)
 
-add_executable(receiver receiver.cxx)
-target_link_libraries(receiver ${CMAKE_DL_LIBS} ers pthread)
+add_executable(ers_receiver receiver.cxx)
+target_link_libraries(ers_receiver ${CMAKE_DL_LIBS} ers pthread)


### PR DESCRIPTION
This PR is to remove the features of ERS that shall not be used directly by dune code anymore. The Logging package offers logging and debugging functionality through the underlying trace package.