### PR TITLE
Missing find_dependency in cmake.in

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(ers VERSION 1.1.0)
+project(ers VERSION 1.1.1)
 
 find_package(daq-cmake REQUIRED )
 find_package(Boost COMPONENTS regex REQUIRED) 

--- a/cmake/ersConfig.cmake.in
+++ b/cmake/ersConfig.cmake.in
@@ -7,7 +7,7 @@ include(CMakeFindDependencyMacro)
 # the place of this comment. Make sure they match up with the
 # find_package calls in your package's CMakeLists.txt file
 
-find_package(Boost COMPONENTS regex REQUIRED) 
+find_dependency(Boost COMPONENTS regex REQUIRED) 
 
 # Figure out whether or not this dependency is an installed package or
 # in repo form

--- a/cmake/ersConfig.cmake.in
+++ b/cmake/ersConfig.cmake.in
@@ -7,7 +7,7 @@ include(CMakeFindDependencyMacro)
 # the place of this comment. Make sure they match up with the
 # find_package calls in your package's CMakeLists.txt file
 
-
+find_package(Boost COMPONENTS regex REQUIRED) 
 
 # Figure out whether or not this dependency is an installed package or
 # in repo form


### PR DESCRIPTION
Adding the missing `find_dependency(Boost COMPONENTS regex REQUIRED)` statement in cmake.in