### PR TITLE
Prep release/fddaq v5.1.0

### DIFF
--- a/.github/workflows/dunedaq-develop-cpp-ci.yml
+++ b/.github/workflows/dunedaq-develop-cpp-ci.yml
@@ -5,14 +5,14 @@ name: build-develop
 on:
   push:
     branches: 
-      - production/v4
+      - develop
       - patch/*
       - prep-release/*
     paths-ignore:
       - 'docs/**'
       - '.github/**'
   pull_request:
-    branches: [ production/v4 ]
+    branches: [ develop ]
   schedule:
     - cron: "0 9 * * *"
 
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - image: "ghcr.io/dune-daq/nightly-release-alma9:production_v4"
+          - image: "ghcr.io/dune-daq/nightly-release-alma9:development_v5"
             os_name: "a9"
     container:
       image: ${{ matrix.image }}
@@ -49,8 +49,10 @@ jobs:
       run: |
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-          setup_dbt latest_v4 || true
+          setup_dbt latest_v5 || true
           release_name="last_fddaq"
+
+          if [[ -n $( sed -r -n '/- name: '$REPO'$/p' daq-release/configs/nddaq/nddaq-develop/release.yaml ) ]] ; then release_name="last_nddaq"; fi
 
           dbt-create -n $release_name dev-${{ matrix.os_name }}
 
@@ -64,7 +66,7 @@ jobs:
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           cd $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}
           source env.sh || true
-
+          test $REPO == "dbe" && spack load dbe || true
           spack unload $REPO || true
           cp -pr $GITHUB_WORKSPACE/DUNE-DAQ/$REPO $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}/sourcecode
           dbt-build # --unittest # --lint

--- a/.github/workflows/dunedaq-v4-cpp-ci.yml
+++ b/.github/workflows/dunedaq-v4-cpp-ci.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-          setup_dbt latest || true
+          setup_dbt latest_v4 || true
           release_name="last_fddaq"
 
           dbt-create -n $release_name dev-${{ matrix.os_name }}

--- a/.github/workflows/dunedaq-v4-cpp-ci.yml
+++ b/.github/workflows/dunedaq-v4-cpp-ci.yml
@@ -5,7 +5,7 @@ name: build-develop
 on:
   push:
     branches: 
-      - develop
+      - production/v4
       - patch/*
       - prep-release/*
     paths-ignore:

--- a/.github/workflows/dunedaq-v4-cpp-ci.yml
+++ b/.github/workflows/dunedaq-v4-cpp-ci.yml
@@ -12,9 +12,9 @@ on:
       - 'docs/**'
       - '.github/**'
   pull_request:
-    branches: [ develop ]
+    branches: [ production/v4 ]
   schedule:
-    - cron: "0 7 * * *"
+    - cron: "0 9 * * *"
 
   workflow_dispatch:
 

--- a/.github/workflows/dunedaq-v4-cpp-ci.yml
+++ b/.github/workflows/dunedaq-v4-cpp-ci.yml
@@ -20,17 +20,15 @@ on:
 
 
 jobs:
-  Spack_Build_against_dev_release:
-    name: spack_build_against_dev_on_${{ matrix.os_name }}
+  Build_against_dev_release:
+    name: build_against_dev_on_${{ matrix.os_name }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - image: "ghcr.io/dune-daq/sl7-slim-externals:spack-dev-v1.1"
-            os_name: "c7"
-          - image: "ghcr.io/dune-daq/c8-slim-externals:spack-dev-v1.1"
-            os_name: "c8"
+          - image: "ghcr.io/dune-daq/nightly-release-alma9:production_v4"
+            os_name: "a9"
     container:
       image: ${{ matrix.image }}
     defaults:
@@ -51,10 +49,9 @@ jobs:
       run: |
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-          setup_dbt latest|| true
+          setup_dbt latest || true
           release_name="last_fddaq"
-          #nd_config=$GITHUB_WORKSPACE/daq-release/configs/nddaq/nddaq-develop/release.yaml
-          #if grep -q "name: ${REPO}\n" $nd_config; then release_name="last_nddaq"; fi
+
           dbt-create -n $release_name dev-${{ matrix.os_name }}
 
     - name: checkout package for CI
@@ -63,32 +60,29 @@ jobs:
         path: ${{ github.repository }}
     
     - name: setup build env, build the repo against the development release
-      #- name: setup build env, build and lint the repo against the development release
       run: |
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           cd $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}
           source env.sh || true
+
           spack unload $REPO || true
           cp -pr $GITHUB_WORKSPACE/DUNE-DAQ/$REPO $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}/sourcecode
-          dbt-build
-          #[[ $REPO == "daq-cmake" ]] && dbt-build || dbt-build --lint
-          dbt-workarea-env
-          #dbt-build --unittest
+          dbt-build # --unittest # --lint
 
     - name: upload build log file
       uses: actions/upload-artifact@v3
       with:
-        name: spack_build_log_${{ matrix.os_name }}
+        name: build_log_${{ matrix.os_name }}
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
 
-          #- name: upload linter output file
-          #uses: actions/upload-artifact@v3
-          #with:
-          #name: spack_linting_log_${{ matrix.os_name }}
-          #path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*
+    # - name: upload linter output file
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: linting_log_${{ matrix.os_name }}
+    #     path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*
 
-          #- name: upload unittest output file
-          #uses: actions/upload-artifact@v2
-          #with:
-          #name: spack_unit_tests_log_${{ matrix.os_name }}
-          #path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/unit_tests*
+    # - name: upload unittest output file
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: unit_tests_log_${{ matrix.os_name }}
+    #     path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/unit_tests*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(ers VERSION 1.5.1)
+project(ers VERSION 1.5.2)
 
 find_package(daq-cmake REQUIRED )
 

--- a/src/Schema.cpp
+++ b/src/Schema.cpp
@@ -77,6 +77,7 @@ void ers::to_schema ( const Issue & i,   dunedaq::ersschema::IssueChain & out) {
     while ( cause_ptr ) {
       auto ptr = out.add_causes() ;
       to_schema( *cause_ptr, *ptr);
+      ptr -> set_severity(ers::to_string(i.severity()));  // severity is forced to be the same as the top issue
       cause_ptr = cause_ptr -> cause();
     }
 


### PR DESCRIPTION
What this PR does is take `ers` v1.5.2, used in both the latest v4 and v5 releases, and merge it into `develop` (i.e., the branch used for the v5 nightlies). 