### PR TITLE
JCF: update the repo to bring it into compliance with the upstream AT…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,8 @@
+# DUNE DAQ modification notice:
+# This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+# Fork baseline commit: 8267df82 (2020-04-14).
+# Renamed since fork: no.
+
 cmake_minimum_required(VERSION 3.12)
 project(ers VERSION 1.5.5)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 # DUNE DAQ modification notice:
 # This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
-# Fork baseline commit: 8267df82 (2020-04-14).
+# Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
 # Renamed since fork: no.
+#
+# Original copyright:
+# Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+# Licensed under the Apache License, Version 2.0.
 
 cmake_minimum_required(VERSION 3.12)
 project(ers VERSION 1.5.5)

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,27 @@
+This repository was forked from the ATLAS ers repository in April 2020
+for the purposes of the DUNE DAQ project. Consistent with the ATLAS
+ers repository's Apache 2.0 license:
+
+* A copy of the original ATLAS ers NOTICE is reproduced below and in
+  licenses_and_notices/NOTICE.
+
+* A copy of the ATLAS ers Apache 2.0 license is included in
+  licenses_and_notices/LICENSE.Apache2.0; it is to be considered only
+  in terms of satisfying ATLAS ers's license terms and not as a
+  licensing of this repository's code as such.
+
+* All modifications to the source files for DUNE DAQ in this
+  repository are marked as such in each file's header.
+
+//////////////////////////////////////////////////////////////////////
+
+Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+Licensed under the Apache License, version 2.0.
+
+Contributors
+============
+ Serguei Kolos <Serguei.Kolos@cern.ch>
+ mwiesman <mwiesman@mail.cern.ch>
+ Andrei Kazarov <Andrei.Kazarov@cern.ch>
+ grosrena <grosrena@mail.cern.ch>
+ Haimo Zobernig <Haimo.Zobernig@cern.ch>

--- a/apps/ers_config.cxx
+++ b/apps/ers_config.cxx
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from bin/config.cxx to apps/ers_config.cxx).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/apps/ers_config.cxx
+++ b/apps/ers_config.cxx
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from bin/config.cxx to apps/ers_config.cxx).
+ */
+
+/*
  *  config.cxx
  *
  *  Created by Serguei Kolos on 24.01.05.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+<!-- DUNE DAQ modification notice: This file has been modified from the original ATLAS ers source for the DUNE DAQ project. Fork baseline commit: 8267df82 (2020-04-14). Renamed since fork: yes (from README.md to docs/README.md). -->
+
 # Error Reporting Service (ERS)
 
 The Error Reporting System (ERS) software package provides a common API for error reporting

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<!-- DUNE DAQ modification notice: This file has been modified from the original ATLAS ers source for the DUNE DAQ project. Fork baseline commit: 8267df82 (2020-04-14). Renamed since fork: yes (from README.md to docs/README.md). -->
+<!-- DUNE DAQ modification notice: This file has been modified from the original ATLAS ers source for the DUNE DAQ project. Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14). Renamed since fork: yes (from README.md to docs/README.md). Original copyright: Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration. Licensed under the Apache License, Version 2.0. -->
 
 # Error Reporting Service (ERS)
 

--- a/include/ers/AnyIssue.hpp
+++ b/include/ers/AnyIssue.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/AnyIssue.h to include/ers/AnyIssue.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/AnyIssue.hpp
+++ b/include/ers/AnyIssue.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/AnyIssue.h to include/ers/AnyIssue.hpp).
+ */
+
+/*
  *  AnyIssue.h
  *  ers
  *

--- a/include/ers/Assertion.hpp
+++ b/include/ers/Assertion.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Assertion.h to include/ers/Assertion.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/Assertion.hpp
+++ b/include/ers/Assertion.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/Assertion.h to include/ers/Assertion.hpp).
+ */
+
+/*
  *  Assertion.h
  *  ers
  *

--- a/include/ers/Configuration.hpp
+++ b/include/ers/Configuration.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Configuration.h to include/ers/Configuration.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_CONFIGURATION_H

--- a/include/ers/Configuration.hpp
+++ b/include/ers/Configuration.hpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/Configuration.h to include/ers/Configuration.hpp).
+ */
+
 #ifndef ERS_CONFIGURATION_H
 #define ERS_CONFIGURATION_H
 

--- a/include/ers/Context.hpp
+++ b/include/ers/Context.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Context.h to include/ers/Context.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/Context.hpp
+++ b/include/ers/Context.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/Context.h to include/ers/Context.hpp).
+ */
+
+/*
  *  Context.h
  *  ers
  *

--- a/include/ers/InputStream.hpp
+++ b/include/ers/InputStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/InputStream.h to include/ers/InputStream.hpp).
+ */
+
+/*
  *  InputStream.h
  *  ers
  *

--- a/include/ers/InputStream.hpp
+++ b/include/ers/InputStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/InputStream.h to include/ers/InputStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/Issue.hpp
+++ b/include/ers/Issue.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Issue.h to include/ers/Issue.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/Issue.hpp
+++ b/include/ers/Issue.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/Issue.h to include/ers/Issue.hpp).
+ */
+
+/*
  *  Issue.h
  *  ers
  *

--- a/include/ers/IssueCatcherHandler.hpp
+++ b/include/ers/IssueCatcherHandler.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/IssueCatcherHandler.h to include/ers/IssueCatcherHandler.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_ISSUE_CATCHER_HANDLER_H

--- a/include/ers/IssueCatcherHandler.hpp
+++ b/include/ers/IssueCatcherHandler.hpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/IssueCatcherHandler.h to include/ers/IssueCatcherHandler.hpp).
+ */
+
 #ifndef ERS_ISSUE_CATCHER_HANDLER_H
 #define ERS_ISSUE_CATCHER_HANDLER_H
 

--- a/include/ers/IssueFactory.hpp
+++ b/include/ers/IssueFactory.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/IssueFactory.h to include/ers/IssueFactory.hpp).
+ */
+
+/*
  *  IssueFactory.h
  *  ers
  *

--- a/include/ers/IssueFactory.hpp
+++ b/include/ers/IssueFactory.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/IssueFactory.h to include/ers/IssueFactory.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/IssueReceiver.hpp
+++ b/include/ers/IssueReceiver.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/IssueReceiver.h to include/ers/IssueReceiver.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/IssueReceiver.hpp
+++ b/include/ers/IssueReceiver.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/IssueReceiver.h to include/ers/IssueReceiver.hpp).
+ */
+
+/*
  *  IssueReceiver.h
  *  ers
  *

--- a/include/ers/LocalContext.hpp
+++ b/include/ers/LocalContext.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/LocalContext.h to include/ers/LocalContext.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/LocalContext.hpp
+++ b/include/ers/LocalContext.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/LocalContext.h to include/ers/LocalContext.hpp).
+ */
+
+/*
  *  LocalContext.h
  *  ers
  *

--- a/include/ers/LocalStream.hpp
+++ b/include/ers/LocalStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/LocalStream.h to include/ers/LocalStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_LOCAL_STREAM_H

--- a/include/ers/LocalStream.hpp
+++ b/include/ers/LocalStream.hpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/LocalStream.h to include/ers/LocalStream.hpp).
+ */
+
 #ifndef ERS_LOCAL_STREAM_H
 #define ERS_LOCAL_STREAM_H
 

--- a/include/ers/OutputStream.hpp
+++ b/include/ers/OutputStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/OutputStream.h to include/ers/OutputStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/OutputStream.hpp
+++ b/include/ers/OutputStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/OutputStream.h to include/ers/OutputStream.hpp).
+ */
+
+/*
  *  OutputStream.h
  *  ers
  *

--- a/include/ers/RemoteContext.hpp
+++ b/include/ers/RemoteContext.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/RemoteContext.h to include/ers/RemoteContext.hpp).
+ */
+
+/*
  *  RemoteContext.h
  *  ers
  *

--- a/include/ers/RemoteContext.hpp
+++ b/include/ers/RemoteContext.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/RemoteContext.h to include/ers/RemoteContext.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/SampleIssues.hpp
+++ b/include/ers/SampleIssues.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/SampleIssues.h to include/ers/SampleIssues.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_SAMPLE_ISSUES_H

--- a/include/ers/SampleIssues.hpp
+++ b/include/ers/SampleIssues.hpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/SampleIssues.h to include/ers/SampleIssues.hpp).
+ */
+
 #ifndef ERS_SAMPLE_ISSUES_H
 #define ERS_SAMPLE_ISSUES_H
 

--- a/include/ers/Severity.hpp
+++ b/include/ers/Severity.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/Severity.h to include/ers/Severity.hpp).
+ */
+
+/*
  *  Severity.h
  *  ers
  *

--- a/include/ers/Severity.hpp
+++ b/include/ers/Severity.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Severity.h to include/ers/Severity.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/StandardStreamOutput.hpp
+++ b/include/ers/StandardStreamOutput.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/StandardStreamOutput.h to include/ers/StandardStreamOutput.hpp).
+ */
+
+/*
  *  StandardStreamOutput.h
  *  ers
  *

--- a/include/ers/StandardStreamOutput.hpp
+++ b/include/ers/StandardStreamOutput.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/StandardStreamOutput.h to include/ers/StandardStreamOutput.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/StreamFactory.hpp
+++ b/include/ers/StreamFactory.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/StreamFactory.h to include/ers/StreamFactory.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/StreamFactory.hpp
+++ b/include/ers/StreamFactory.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/StreamFactory.h to include/ers/StreamFactory.hpp).
+ */
+
+/*
  *  StreamFactory.h
  *  ers
  *

--- a/include/ers/StreamManager.hpp
+++ b/include/ers/StreamManager.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/StreamManager.h to include/ers/StreamManager.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/StreamManager.hpp
+++ b/include/ers/StreamManager.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/StreamManager.h to include/ers/StreamManager.hpp).
+ */
+
+/*
  *  StreamManager.h
  *  ers
  *

--- a/include/ers/ers.hpp
+++ b/include/ers/ers.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/ers.h to include/ers/ers.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/ers.hpp
+++ b/include/ers/ers.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/ers.h to include/ers/ers.hpp).
+ */
+
+/*
  *  ers.h
  *  ers
  *

--- a/include/ers/internal/AbortStream.hpp
+++ b/include/ers/internal/AbortStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/AbortStream.h to include/ers/internal/AbortStream.hpp).
+ */
+
+/*
  *  AbortStream.h
  *  ers
  *

--- a/include/ers/internal/AbortStream.hpp
+++ b/include/ers/internal/AbortStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/AbortStream.h to include/ers/internal/AbortStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/ExitStream.hpp
+++ b/include/ers/internal/ExitStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/ExitStream.h to include/ers/internal/ExitStream.hpp).
+ */
+
+/*
  *  ExitStream.h
  *  ers
  *

--- a/include/ers/internal/ExitStream.hpp
+++ b/include/ers/internal/ExitStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/ExitStream.h to include/ers/internal/ExitStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/FilterStream.hpp
+++ b/include/ers/internal/FilterStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/FilterStream.h to include/ers/internal/FilterStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/FilterStream.hpp
+++ b/include/ers/internal/FilterStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/FilterStream.h to include/ers/internal/FilterStream.hpp).
+ */
+
+/*
  *  FilterStream.h
  *  ERS
  *

--- a/include/ers/internal/FormattedStandardStream.hxx
+++ b/include/ers/internal/FormattedStandardStream.hxx
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/FormattedStandardStream.inc to include/ers/internal/FormattedStandardStream.hxx).
+ */
+
+/*
  *  FormattedStandardStream.i
  *  ers
  *

--- a/include/ers/internal/FormattedStandardStream.hxx
+++ b/include/ers/internal/FormattedStandardStream.hxx
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/FormattedStandardStream.inc to include/ers/internal/FormattedStandardStream.hxx).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/GlobalLockStream.hpp
+++ b/include/ers/internal/GlobalLockStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/GlobalLockStream.h to include/ers/internal/GlobalLockStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/GlobalLockStream.hpp
+++ b/include/ers/internal/GlobalLockStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/GlobalLockStream.h to include/ers/internal/GlobalLockStream.hpp).
+ */
+
+/*
  *  LockStream.h
  *  ers
  *

--- a/include/ers/internal/IssueDeclarationMacro.hpp
+++ b/include/ers/internal/IssueDeclarationMacro.hpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/IssueDeclarationMacro.h to include/ers/internal/IssueDeclarationMacro.hpp).
+ */
+
 #ifndef ERS_ISSUE_DECLARATION_MACRO_H
 #define ERS_ISSUE_DECLARATION_MACRO_H
 

--- a/include/ers/internal/IssueDeclarationMacro.hpp
+++ b/include/ers/internal/IssueDeclarationMacro.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/IssueDeclarationMacro.h to include/ers/internal/IssueDeclarationMacro.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_ISSUE_DECLARATION_MACRO_H

--- a/include/ers/internal/LockStream.hpp
+++ b/include/ers/internal/LockStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/LockStream.h to include/ers/internal/LockStream.hpp).
+ */
+
+/*
  *  LockStream.h
  *  ers
  *

--- a/include/ers/internal/LockStream.hpp
+++ b/include/ers/internal/LockStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/LockStream.h to include/ers/internal/LockStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/NullStream.hpp
+++ b/include/ers/internal/NullStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/NullStream.h to include/ers/internal/NullStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/NullStream.hpp
+++ b/include/ers/internal/NullStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/NullStream.h to include/ers/internal/NullStream.hpp).
+ */
+
+/*
  *  NullStream.h
  *  ers
  *

--- a/include/ers/internal/PluginManager.hpp
+++ b/include/ers/internal/PluginManager.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/PluginManager.h to include/ers/internal/PluginManager.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/PluginManager.hpp
+++ b/include/ers/internal/PluginManager.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/PluginManager.h to include/ers/internal/PluginManager.hpp).
+ */
+
+/*
  *  PluginManager.h
  *  ers
  *

--- a/include/ers/internal/RFilterStream.hpp
+++ b/include/ers/internal/RFilterStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/RFilterStream.h to include/ers/internal/RFilterStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/RFilterStream.hpp
+++ b/include/ers/internal/RFilterStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/RFilterStream.h to include/ers/internal/RFilterStream.hpp).
+ */
+
+/*
  *  RFilterStream.h
  *  ERS
  *

--- a/include/ers/internal/SingletonCreator.hpp
+++ b/include/ers/internal/SingletonCreator.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/SingletonCreator.h to include/ers/internal/SingletonCreator.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_SINGLETON_CREATOR_H

--- a/include/ers/internal/SingletonCreator.hpp
+++ b/include/ers/internal/SingletonCreator.hpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/SingletonCreator.h to include/ers/internal/SingletonCreator.hpp).
+ */
+
 #ifndef ERS_SINGLETON_CREATOR_H
 #define ERS_SINGLETON_CREATOR_H
 

--- a/include/ers/internal/StandardStream.hpp
+++ b/include/ers/internal/StandardStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/StandardStream.h to include/ers/internal/StandardStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/StandardStream.hpp
+++ b/include/ers/internal/StandardStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/StandardStream.h to include/ers/internal/StandardStream.hpp).
+ */
+
+/*
  *  StandardStream.h
  *  ers
  *

--- a/include/ers/internal/ThrottleStream.hpp
+++ b/include/ers/internal/ThrottleStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/ThrottleStream.h to include/ers/internal/ThrottleStream.hpp).
+ */
+
+/*
  *  ThrottleStream.h
  *  ers
  *

--- a/include/ers/internal/ThrottleStream.hpp
+++ b/include/ers/internal/ThrottleStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/ThrottleStream.h to include/ers/internal/ThrottleStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/ThrowStream.hpp
+++ b/include/ers/internal/ThrowStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/ThrowStream.h to include/ers/internal/ThrowStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/ThrowStream.hpp
+++ b/include/ers/internal/ThrowStream.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/ThrowStream.h to include/ers/internal/ThrowStream.hpp).
+ */
+
+/*
  *  ThrowStream.h
  *  ers
  *

--- a/include/ers/internal/Util.hpp
+++ b/include/ers/internal/Util.hpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/Util.h to include/ers/internal/Util.hpp).
+ */
+
+/*
  *  Util.h
  *  ers
  *

--- a/include/ers/internal/Util.hpp
+++ b/include/ers/internal/Util.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/Util.h to include/ers/internal/Util.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/macro.hpp
+++ b/include/ers/internal/macro.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/macro.h to include/ers/internal/macro.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_MACRO_H

--- a/include/ers/internal/macro.hpp
+++ b/include/ers/internal/macro.hpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from ers/internal/macro.h to include/ers/internal/macro.hpp).
+ */
+
 #ifndef ERS_MACRO_H
 #define ERS_MACRO_H
 

--- a/licenses_and_notices/LICENSE.Apache2.0
+++ b/licenses_and_notices/LICENSE.Apache2.0
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/licenses_and_notices/NOTICE
+++ b/licenses_and_notices/NOTICE
@@ -1,0 +1,28 @@
+
+This repository was forked from the ATLAS ers repository in April 2020
+for the purposes of the DUNE DAQ project. Consistent with the ATLAS
+ers repository's Apache 2.0 license:
+
+* A copy of the original ATLAS ers NOTICE is cut-and-pasted into this
+  NOTICE (at the bottom, below the "/"'s)
+
+* A copy of the ATLAS ers Apache 2.0 license is included in this
+  directory; it is to be considered only in terms of satisfying ATLAS
+  ers's license terms and not as a licensing of this repository's code
+  as such.
+
+* All modifications to the source files for DUNE DAQ in this
+  repository are marked as such.
+
+//////////////////////////////////////////////////////////////////////
+
+Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+Licensed under the Apache License, version 2.0.
+
+Contributors
+============
+ Serguei Kolos <Serguei.Kolos@cern.ch>
+ mwiesman <mwiesman@mail.cern.ch>
+ Andrei Kazarov <Andrei.Kazarov@cern.ch>
+ grosrena <grosrena@mail.cern.ch>
+ Haimo Zobernig <Haimo.Zobernig@cern.ch>

--- a/licenses_and_notices/NOTICE.ers_ATLAS
+++ b/licenses_and_notices/NOTICE.ers_ATLAS
@@ -1,0 +1,10 @@
+Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+Licensed under the Apache License, version 2.0.
+
+Contributors
+============
+ Serguei Kolos <Serguei.Kolos@cern.ch>
+ mwiesman <mwiesman@mail.cern.ch>
+ Andrei Kazarov <Andrei.Kazarov@cern.ch>
+ grosrena <grosrena@mail.cern.ch>
+ Haimo Zobernig <Haimo.Zobernig@cern.ch>

--- a/plugins/AbortStream.cpp
+++ b/plugins/AbortStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Renamed since fork: yes (from src/streams/AbortStream.cxx to plugins/AbortStream.cpp).
+ */
+
+/*
  *  AbortStream.cxx
  *  ers
  *

--- a/plugins/AbortStream.cpp
+++ b/plugins/AbortStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/AbortStream.cxx to plugins/AbortStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/ExitStream.cpp
+++ b/plugins/ExitStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/ExitStream.cxx to plugins/ExitStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/ExitStream.cpp
+++ b/plugins/ExitStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/streams/ExitStream.cxx to plugins/ExitStream.cpp).
+ */
+
+/*
  *  ExitStream.cxx
  *  ers
  *

--- a/plugins/FilterStream.cpp
+++ b/plugins/FilterStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/streams/FilterStream.cxx to plugins/FilterStream.cpp).
+ */
+
+/*
  *  FilterStream.cxx
  *  ers
  *

--- a/plugins/FilterStream.cpp
+++ b/plugins/FilterStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/FilterStream.cxx to plugins/FilterStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/GlobalLockStream.cpp
+++ b/plugins/GlobalLockStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/GlobalLockStream.cxx to plugins/GlobalLockStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/GlobalLockStream.cpp
+++ b/plugins/GlobalLockStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/streams/GlobalLockStream.cxx to plugins/GlobalLockStream.cpp).
+ */
+
+/*
  *  LockStream.cxx
  *  ers
  *

--- a/plugins/LockStream.cpp
+++ b/plugins/LockStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Renamed since fork: yes (from src/streams/LockStream.cxx to plugins/LockStream.cpp).
+ */
+
+/*
  *  LockStream.cxx
  *  ers
  *

--- a/plugins/LockStream.cpp
+++ b/plugins/LockStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/LockStream.cxx to plugins/LockStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/NullStream.cpp
+++ b/plugins/NullStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/NullStream.cxx to plugins/NullStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/NullStream.cpp
+++ b/plugins/NullStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Renamed since fork: yes (from src/streams/NullStream.cxx to plugins/NullStream.cpp).
+ */
+
+/*
  *  NullStream.cxx
  *  ers
  *

--- a/plugins/RFilterStream.cpp
+++ b/plugins/RFilterStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/streams/RFilterStream.cxx to plugins/RFilterStream.cpp).
+ */
+
+/*
  *  RFilterStream.cxx
  *  ers
  *

--- a/plugins/RFilterStream.cpp
+++ b/plugins/RFilterStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/RFilterStream.cxx to plugins/RFilterStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/StandardStream.cpp
+++ b/plugins/StandardStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/streams/StandardStream.cxx to plugins/StandardStream.cpp).
+ */
+
+/*
  *  StandardStream.cxx
  *  ers
  *

--- a/plugins/StandardStream.cpp
+++ b/plugins/StandardStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/StandardStream.cxx to plugins/StandardStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/ThrottleStream.cpp
+++ b/plugins/ThrottleStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/streams/ThrottleStream.cxx to plugins/ThrottleStream.cpp).
+ */
+
+/*
  *  ThrottleStream.cxx
  *  ers
  *

--- a/plugins/ThrottleStream.cpp
+++ b/plugins/ThrottleStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/ThrottleStream.cxx to plugins/ThrottleStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/ThrowStream.cpp
+++ b/plugins/ThrowStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/ThrowStream.cxx to plugins/ThrowStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/ThrowStream.cpp
+++ b/plugins/ThrowStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Renamed since fork: yes (from src/streams/ThrowStream.cxx to plugins/ThrowStream.cpp).
+ */
+
+/*
  *  ThrowStream.cxx
  *  ers
  *

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Configuration.cxx to src/Configuration.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/Configuration.cxx to src/Configuration.cpp).
+ */
+
+/*
  *  Configuration.cxx
  *  ERS
  *

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Context.cxx to src/Context.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/Context.cxx to src/Context.cpp).
+ */
+
+/*
  *  Context.cxx
  *  ers
  *

--- a/src/ErrorHandler.cpp
+++ b/src/ErrorHandler.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/ErrorHandler.cxx to src/ErrorHandler.cpp).
+ */
+
+/*
  *  ErrorHandler.cxx
  *  ers
  *

--- a/src/ErrorHandler.cpp
+++ b/src/ErrorHandler.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/ErrorHandler.cxx to src/ErrorHandler.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/InputStream.cpp
+++ b/src/InputStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/InputStream.cxx to src/InputStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/InputStream.cpp
+++ b/src/InputStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/InputStream.cxx to src/InputStream.cpp).
+ */
+
+/*
  *  InputStream.cxx
  *  ers
  *

--- a/src/Issue.cpp
+++ b/src/Issue.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/Issue.cxx to src/Issue.cpp).
+ */
+
+/*
  *  Issue.cxx
  *  ers
  *

--- a/src/Issue.cpp
+++ b/src/Issue.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Issue.cxx to src/Issue.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/IssueCatcherHandler.cpp
+++ b/src/IssueCatcherHandler.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Renamed since fork: yes (from src/IssueCatcherHandler.cxx to src/IssueCatcherHandler.cpp).
+ */
+
+/*
  *  IssueCatcherHandler.cxx
  *  ERS
  *

--- a/src/IssueCatcherHandler.cpp
+++ b/src/IssueCatcherHandler.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/IssueCatcherHandler.cxx to src/IssueCatcherHandler.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/IssueFactory.cpp
+++ b/src/IssueFactory.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/IssueFactory.cxx to src/IssueFactory.cpp).
+ */
+
+/*
  *  IssueFactory.cxx
  *  ers
  *

--- a/src/IssueFactory.cpp
+++ b/src/IssueFactory.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/IssueFactory.cxx to src/IssueFactory.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/LocalContext.cpp
+++ b/src/LocalContext.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/LocalContext.cxx to src/LocalContext.cpp).
+ */
+
+/*
  *  LocalContext.cxx
  *  ers
  *

--- a/src/LocalContext.cpp
+++ b/src/LocalContext.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/LocalContext.cxx to src/LocalContext.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/LocalStream.cpp
+++ b/src/LocalStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/LocalStream.cxx to src/LocalStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/LocalStream.cpp
+++ b/src/LocalStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/LocalStream.cxx to src/LocalStream.cpp).
+ */
+
+/*
  *  LocalStream.cxx
  *  ERS
  *

--- a/src/OutputStream.cpp
+++ b/src/OutputStream.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/OutputStream.cxx to src/OutputStream.cpp).
+ */
+
+/*
  *  OutputStream.cxx
  *  ers
  *

--- a/src/OutputStream.cpp
+++ b/src/OutputStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/OutputStream.cxx to src/OutputStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/PluginManager.cxx to src/PluginManager.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef __rtems__

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/PluginManager.cxx to src/PluginManager.cpp).
+ */
+
 #ifndef __rtems__
 #include <dlfcn.h>
 #endif

--- a/src/SampleIssues.cpp
+++ b/src/SampleIssues.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/SampleIssues.cxx to src/SampleIssues.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #include <ers/SampleIssues.hpp>

--- a/src/SampleIssues.cpp
+++ b/src/SampleIssues.cpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/SampleIssues.cxx to src/SampleIssues.cpp).
+ */
+
 #include <ers/SampleIssues.hpp>
 
 /** \def ers::File This is the base class for all file related issues. 

--- a/src/Severity.cpp
+++ b/src/Severity.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Severity.cxx to src/Severity.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #include <assert.h>

--- a/src/Severity.cpp
+++ b/src/Severity.cpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/Severity.cxx to src/Severity.cpp).
+ */
+
 #include <assert.h>
 #include <sstream>
 #include <ers/ers.hpp>

--- a/src/StandardStreamOutput.cpp
+++ b/src/StandardStreamOutput.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/StandardStreamOutput.cxx to src/StandardStreamOutput.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/StandardStreamOutput.cpp
+++ b/src/StandardStreamOutput.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/StandardStreamOutput.cxx to src/StandardStreamOutput.cpp).
+ */
+
+/*
  *  StandardStreamOutput.cxx
  *  ers
  *

--- a/src/StreamFactory.cpp
+++ b/src/StreamFactory.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/StreamFactory.cxx to src/StreamFactory.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/StreamFactory.cpp
+++ b/src/StreamFactory.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/StreamFactory.cxx to src/StreamFactory.cpp).
+ */
+
+/*
  *  StreamFactory.cxx
  *  ERS
  *

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -1,4 +1,11 @@
 /*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/StreamManager.cxx to src/StreamManager.cpp).
+ */
+
+/*
  *  StreamManager.cxx
  *  ERS
  *

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/StreamManager.cxx to src/StreamManager.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1,3 +1,10 @@
+/*
+ * DUNE DAQ modification notice:
+ * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
+ * Fork baseline commit: 8267df82 (2020-04-14).
+ * Renamed since fork: yes (from src/Util.cxx to src/Util.cpp).
+ */
+
 #include <stdio.h>
 
 #include <ers/internal/Util.hpp>

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Util.cxx to src/Util.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #include <stdio.h>


### PR DESCRIPTION
…LAS ers repo's Apache v2.0 license

# Description

Long story short, the upstream ATLAS ers repo from which this repo was originally forked has an Apache v2.0 license. As this repo is what would be considered a "Derivative Work", the changes in this PR bring this repo into compliance with the standards of its upstream repo's software license. 

## Type of change

- [X ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

I skipped things like unit testing as this is a documentation change. 

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

