### PR TITLE
Fix Apache v2.0 compliance gaps in modification notices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,11 @@
 # DUNE DAQ modification notice:
 # This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
-# Fork baseline commit: 8267df82 (2020-04-14).
+# Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
 # Renamed since fork: no.
+#
+# Original copyright:
+# Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+# Licensed under the Apache License, Version 2.0.
 
 cmake_minimum_required(VERSION 3.12)
 project(ers VERSION 1.5.5)

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,27 @@
+This repository was forked from the ATLAS ers repository in April 2020
+for the purposes of the DUNE DAQ project. Consistent with the ATLAS
+ers repository's Apache 2.0 license:
+
+* A copy of the original ATLAS ers NOTICE is reproduced below and in
+  licenses_and_notices/NOTICE.
+
+* A copy of the ATLAS ers Apache 2.0 license is included in
+  licenses_and_notices/LICENSE.Apache2.0; it is to be considered only
+  in terms of satisfying ATLAS ers's license terms and not as a
+  licensing of this repository's code as such.
+
+* All modifications to the source files for DUNE DAQ in this
+  repository are marked as such in each file's header.
+
+//////////////////////////////////////////////////////////////////////
+
+Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+Licensed under the Apache License, version 2.0.
+
+Contributors
+============
+ Serguei Kolos <Serguei.Kolos@cern.ch>
+ mwiesman <mwiesman@mail.cern.ch>
+ Andrei Kazarov <Andrei.Kazarov@cern.ch>
+ grosrena <grosrena@mail.cern.ch>
+ Haimo Zobernig <Haimo.Zobernig@cern.ch>

--- a/apps/ers_config.cxx
+++ b/apps/ers_config.cxx
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from bin/config.cxx to apps/ers_config.cxx).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-<!-- DUNE DAQ modification notice: This file has been modified from the original ATLAS ers source for the DUNE DAQ project. Fork baseline commit: 8267df82 (2020-04-14). Renamed since fork: yes (from README.md to docs/README.md). -->
+<!-- DUNE DAQ modification notice: This file has been modified from the original ATLAS ers source for the DUNE DAQ project. Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14). Renamed since fork: yes (from README.md to docs/README.md). Original copyright: Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration. Licensed under the Apache License, Version 2.0. -->
 
 # Error Reporting Service (ERS)
 

--- a/include/ers/AnyIssue.hpp
+++ b/include/ers/AnyIssue.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/AnyIssue.h to include/ers/AnyIssue.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/Assertion.hpp
+++ b/include/ers/Assertion.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Assertion.h to include/ers/Assertion.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/Configuration.hpp
+++ b/include/ers/Configuration.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Configuration.h to include/ers/Configuration.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_CONFIGURATION_H

--- a/include/ers/Context.hpp
+++ b/include/ers/Context.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Context.h to include/ers/Context.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/InputStream.hpp
+++ b/include/ers/InputStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/InputStream.h to include/ers/InputStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/Issue.hpp
+++ b/include/ers/Issue.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Issue.h to include/ers/Issue.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/IssueCatcherHandler.hpp
+++ b/include/ers/IssueCatcherHandler.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/IssueCatcherHandler.h to include/ers/IssueCatcherHandler.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_ISSUE_CATCHER_HANDLER_H

--- a/include/ers/IssueFactory.hpp
+++ b/include/ers/IssueFactory.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/IssueFactory.h to include/ers/IssueFactory.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/IssueReceiver.hpp
+++ b/include/ers/IssueReceiver.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/IssueReceiver.h to include/ers/IssueReceiver.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/LocalContext.hpp
+++ b/include/ers/LocalContext.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/LocalContext.h to include/ers/LocalContext.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/LocalStream.hpp
+++ b/include/ers/LocalStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/LocalStream.h to include/ers/LocalStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_LOCAL_STREAM_H

--- a/include/ers/OutputStream.hpp
+++ b/include/ers/OutputStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/OutputStream.h to include/ers/OutputStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/RemoteContext.hpp
+++ b/include/ers/RemoteContext.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/RemoteContext.h to include/ers/RemoteContext.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/SampleIssues.hpp
+++ b/include/ers/SampleIssues.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/SampleIssues.h to include/ers/SampleIssues.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_SAMPLE_ISSUES_H

--- a/include/ers/Severity.hpp
+++ b/include/ers/Severity.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/Severity.h to include/ers/Severity.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/StandardStreamOutput.hpp
+++ b/include/ers/StandardStreamOutput.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/StandardStreamOutput.h to include/ers/StandardStreamOutput.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/StreamFactory.hpp
+++ b/include/ers/StreamFactory.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/StreamFactory.h to include/ers/StreamFactory.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/StreamManager.hpp
+++ b/include/ers/StreamManager.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/StreamManager.h to include/ers/StreamManager.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/ers.hpp
+++ b/include/ers/ers.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/ers.h to include/ers/ers.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/AbortStream.hpp
+++ b/include/ers/internal/AbortStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/AbortStream.h to include/ers/internal/AbortStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/ExitStream.hpp
+++ b/include/ers/internal/ExitStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/ExitStream.h to include/ers/internal/ExitStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/FilterStream.hpp
+++ b/include/ers/internal/FilterStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/FilterStream.h to include/ers/internal/FilterStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/FormattedStandardStream.hxx
+++ b/include/ers/internal/FormattedStandardStream.hxx
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/FormattedStandardStream.inc to include/ers/internal/FormattedStandardStream.hxx).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/GlobalLockStream.hpp
+++ b/include/ers/internal/GlobalLockStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/GlobalLockStream.h to include/ers/internal/GlobalLockStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/IssueDeclarationMacro.hpp
+++ b/include/ers/internal/IssueDeclarationMacro.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/IssueDeclarationMacro.h to include/ers/internal/IssueDeclarationMacro.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_ISSUE_DECLARATION_MACRO_H

--- a/include/ers/internal/LockStream.hpp
+++ b/include/ers/internal/LockStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/LockStream.h to include/ers/internal/LockStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/NullStream.hpp
+++ b/include/ers/internal/NullStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/NullStream.h to include/ers/internal/NullStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/PluginManager.hpp
+++ b/include/ers/internal/PluginManager.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/PluginManager.h to include/ers/internal/PluginManager.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/RFilterStream.hpp
+++ b/include/ers/internal/RFilterStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/RFilterStream.h to include/ers/internal/RFilterStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/SingletonCreator.hpp
+++ b/include/ers/internal/SingletonCreator.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/SingletonCreator.h to include/ers/internal/SingletonCreator.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_SINGLETON_CREATOR_H

--- a/include/ers/internal/StandardStream.hpp
+++ b/include/ers/internal/StandardStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/StandardStream.h to include/ers/internal/StandardStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/ThrottleStream.hpp
+++ b/include/ers/internal/ThrottleStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/ThrottleStream.h to include/ers/internal/ThrottleStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/ThrowStream.hpp
+++ b/include/ers/internal/ThrowStream.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/ThrowStream.h to include/ers/internal/ThrowStream.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/Util.hpp
+++ b/include/ers/internal/Util.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/Util.h to include/ers/internal/Util.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/include/ers/internal/macro.hpp
+++ b/include/ers/internal/macro.hpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from ers/internal/macro.h to include/ers/internal/macro.hpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef ERS_MACRO_H

--- a/plugins/AbortStream.cpp
+++ b/plugins/AbortStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/AbortStream.cxx to plugins/AbortStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/ExitStream.cpp
+++ b/plugins/ExitStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/ExitStream.cxx to plugins/ExitStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/FilterStream.cpp
+++ b/plugins/FilterStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/FilterStream.cxx to plugins/FilterStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/GlobalLockStream.cpp
+++ b/plugins/GlobalLockStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/GlobalLockStream.cxx to plugins/GlobalLockStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/LockStream.cpp
+++ b/plugins/LockStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/LockStream.cxx to plugins/LockStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/NullStream.cpp
+++ b/plugins/NullStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/NullStream.cxx to plugins/NullStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/RFilterStream.cpp
+++ b/plugins/RFilterStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/RFilterStream.cxx to plugins/RFilterStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/StandardStream.cpp
+++ b/plugins/StandardStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/StandardStream.cxx to plugins/StandardStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/ThrottleStream.cpp
+++ b/plugins/ThrottleStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/ThrottleStream.cxx to plugins/ThrottleStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/plugins/ThrowStream.cpp
+++ b/plugins/ThrowStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/streams/ThrowStream.cxx to plugins/ThrowStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/Configuration.cpp
+++ b/src/Configuration.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Configuration.cxx to src/Configuration.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Context.cxx to src/Context.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/ErrorHandler.cpp
+++ b/src/ErrorHandler.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/ErrorHandler.cxx to src/ErrorHandler.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/InputStream.cpp
+++ b/src/InputStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/InputStream.cxx to src/InputStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/Issue.cpp
+++ b/src/Issue.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Issue.cxx to src/Issue.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/IssueCatcherHandler.cpp
+++ b/src/IssueCatcherHandler.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14T15:33:10+02:00).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/IssueCatcherHandler.cxx to src/IssueCatcherHandler.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/IssueFactory.cpp
+++ b/src/IssueFactory.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/IssueFactory.cxx to src/IssueFactory.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/LocalContext.cpp
+++ b/src/LocalContext.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/LocalContext.cxx to src/LocalContext.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/LocalStream.cpp
+++ b/src/LocalStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/LocalStream.cxx to src/LocalStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/OutputStream.cpp
+++ b/src/OutputStream.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/OutputStream.cxx to src/OutputStream.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/PluginManager.cxx to src/PluginManager.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #ifndef __rtems__

--- a/src/SampleIssues.cpp
+++ b/src/SampleIssues.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/SampleIssues.cxx to src/SampleIssues.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #include <ers/SampleIssues.hpp>

--- a/src/Severity.cpp
+++ b/src/Severity.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Severity.cxx to src/Severity.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #include <assert.h>

--- a/src/StandardStreamOutput.cpp
+++ b/src/StandardStreamOutput.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/StandardStreamOutput.cxx to src/StandardStreamOutput.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/StreamFactory.cpp
+++ b/src/StreamFactory.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/StreamFactory.cxx to src/StreamFactory.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/StreamManager.cpp
+++ b/src/StreamManager.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/StreamManager.cxx to src/StreamManager.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 /*

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -1,8 +1,12 @@
 /*
  * DUNE DAQ modification notice:
  * This file has been modified from the original ATLAS ers source for the DUNE DAQ project.
- * Fork baseline commit: 8267df82 (2020-04-14).
+ * Fork baseline commit: 8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14).
  * Renamed since fork: yes (from src/Util.cxx to src/Util.cpp).
+ *
+ * Original copyright:
+ * Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration.
+ * Licensed under the Apache License, Version 2.0.
  */
 
 #include <stdio.h>


### PR DESCRIPTION
## Summary

This PR addresses three Apache v2.0 compliance gaps identified in review of #51:

- **§4(c) — upstream copyright in per-file headers**: Every modified file now carries the original CERN copyright line (`Copyright (C) 2001-2020 CERN for the benefit of the ATLAS collaboration`) inside its `DUNE DAQ modification notice` block. Apache 2.0 §4(c) requires retaining all copyright notices from the Source form of the Work in each distributed file.

- **§4(d) — root-level NOTICE file**: A `NOTICE` file is added at the repository root. The `licenses_and_notices/NOTICE` subdirectory placement is technically permitted by §4(d), but the root-level location is the conventional expectation of downstream packagers and automated license/SBOM scanners (FOSSA, REUSE, etc.).

- **Consistent commit hash format**: All fork baseline commit hashes are normalized to the full 40-character SHA-1 (`8267df82a4f6fe6bf02c4014923eba19eddc4614 (2020-04-14)`), replacing the abbreviated 8-char form used in most files and the ISO-8601 timestamp variant used in a few.

## Test plan

- [x] Verify `NOTICE` exists at repo root and its content matches `licenses_and_notices/NOTICE`
- [ ] Spot-check several modified source files to confirm the copyright block appears in each notice header
- [ ] Confirm no abbreviated `8267df82` commit hash remains (`grep -r "8267df82 " . --include="*.cpp" --include="*.hpp"` should return nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)